### PR TITLE
[geotrans] Add sources using LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+geotrans/geotrans-3.8.tgz filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[remote "origin"]
+	lfsurl = https://c3i.jfrog.io/artifactory/api/lfs/cci-sources-backup

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ A more general and robust solution will be released in the following months.
 > **Note.-** **Do not use these sources.** We might remove, rename, move or change them
 > without previous notice. 
 
+> **Note.-** We are using Git LFS to store large files using Artifactory as backend.

--- a/geotrans/README.md
+++ b/geotrans/README.md
@@ -1,0 +1,9 @@
+geotrans
+========
+
+NGA doesn't provide versioned sources of the library, meaning that with each new release existing sources for old
+releases will be lost and builds will no longer be reproducible (original issue and rationale: https://github.com/conan-io/conan-center-index/pull/6512).
+
+This folder contains snapshots of the sources as they are retrieved from `https://earth-info.nga.mil/php/download.php?file=wgs-mastertgz`:
+
+ * `geotrans-3.8.tgz`: retrieved on 2021-10-13

--- a/geotrans/geotrans-3.8.tgz
+++ b/geotrans/geotrans-3.8.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baa72d3b1ae12f237a8ad30f2deb3fed2b80feb759528ea0a72b4b42cb77c565
+size 159618792


### PR DESCRIPTION
This works, and it helps us to keep track of sources (git repository stores the sha256 of the file (which is the path in the Artifactory repo)... however, going from the pointer in Github:

```
version https://git-lfs.github.com/spec/v1
oid sha256:baa72d3b1ae12f237a8ad30f2deb3fed2b80feb759528ea0a72b4b42cb77c565
size 159618792
```

to the actual URL:

```
https://c3i.jfrog.io/artifactory/cci-sources-backup/objects/ba/a7/baa72d3b1ae12f237a8ad30f2deb3fed2b80feb759528ea0a72b4b42cb77c565
```

Requires some manual intervention or internal knowledge about how git-lfs works...
